### PR TITLE
Make clicking on a search result focus the right town

### DIFF
--- a/src/map/townsearch.js
+++ b/src/map/townsearch.js
@@ -124,12 +124,12 @@ function startSearch() {
     }
 
     //Separate loop to add all the event listeners
-    var idx2 = 0;
+    idx = 0;
     for (const result of results) 
     {
-      const ele = document.getElementById(`result${idx2}`)
+      const ele = document.getElementById(`result${idx}`)
       ele.onclick = () => focusMap(result.X, result.Z);
-      idx2++
+      idx++
     }
   }
 }


### PR DESCRIPTION
Previously, city map would only attach an onClick() event to the first element in the search results. When clicked, it would focus the map onto the coordinates of the town at the bottom of search results. This PR fixes that behavior and makes it so that each element in the search results is clickable and focuses on the right location when clicked.